### PR TITLE
attempt to fix route

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,7 +1,7 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 
 const router = createRouter({
-    history: createWebHistory(import.meta.env.BASE_URL),
+    history: createWebHashHistory(import.meta.env.BASE_URL),
     routes: [
         {
             path: '/',


### PR DESCRIPTION
Deployment on netlify does not allow reloading from subdirectory (e.g. /content or /content/:id path). This is an attempt to fix which uses web hash history instead of web history.